### PR TITLE
Cleanup .vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -49,7 +49,7 @@ set nu
 set nowrap
 set hlsearch
 
-" Letzten CHANGELOG.md Versionseintrag kopieren
+" Copy the last CHANGELOG.md entry
 let @a = '3yjPjjllDA'
 
 highlight HonorGroup ctermfg=magenta ctermbg=lightgreen
@@ -59,7 +59,6 @@ highlight InspireGroup ctermfg=magenta ctermbg=lightyellow
 highlight SuccessGroup ctermfg=magenta ctermbg=white
 highlight LearnGroup ctermfg=magenta ctermbg=white
 highlight TrustGroup ctermfg=magenta ctermbg=white
-highlight ShareGroup ctermfg=magenta ctermbg=lightgreen
 highlight ShareGroup ctermfg=magenta ctermbg=lightgreen
 highlight FulfillmentGroup ctermfg=magenta ctermbg=lightyellow
 highlight HappinessGroup ctermfg=magenta ctermbg=lightgreen
@@ -75,10 +74,10 @@ autocmd BufRead,BufNewFile *.tid syntax match FulfillmentGroup "\<[Ff]ulfillment
 autocmd BufRead,BufNewFile *.tid syntax match HappinessGroup "\<[Hh]appiness\>"
 autocmd BufRead,BufNewFile *.tid syntax match SuccessGroup "\<[Ss]uccess\w*\>"
 autocmd BufRead,BufNewFile *.tid syntax match LearnGroup "\<[Ll]earn\w*\>"
-autocmd BufRead,BufNewFile *.tid syntax match LearnGroup "\<[Tt]rust\w*\>"
+autocmd BufRead,BufNewFile *.tid syntax match TrustGroup "\<[Tt]rust\w*\>"
 autocmd BufRead,BufNewFile *.tid syntax match ShareGroup "\<[Ss]hare\>"
 
-" Ich mag es lieber wenn die akive Zeile nicht unterstrichen wird sondern farblich hervorgehoben wird.
+" I prefer the active line to be highlighted with color instead of being underlined.
 hi CursorLine cterm=NONE ctermfg=LightBlue ctermbg=NONE guibg=NONE guifg=NONE
 
 " Change Color when entering Insert Mode

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Vundle Installation and Plugin Management
+# Dotfiles Repository
+
+This repository is intended to share my dotfiles which I created during my learnings of Linux and the GNU tools.
+
+## Vundle Installation and Plugin Management
 
 Vundle is a plugin manager for Vim. To install Vundle, follow these steps:
 
@@ -33,7 +37,7 @@ Vundle is a plugin manager for Vim. To install Vundle, follow these steps:
    :PluginInstall
    ```
 
-# Using Autocommands
+## Using Autocommands
 
 Autocommands in Vim allow you to execute commands automatically in response to specific events. Here are some examples of how to use autocommands:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Vundle Installation and Plugin Management
+
+Vundle is a plugin manager for Vim. To install Vundle, follow these steps:
+
+1. Open a terminal and run the following command to clone the Vundle repository:
+   ```
+   git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+   ```
+
+2. Add the following lines to your `.vimrc` file to set up Vundle:
+   ```
+   set nocompatible              " be iMproved, required
+   filetype off                  " required
+
+   " set the runtime path to include Vundle and initialize
+   set rtp+=~/.vim/bundle/Vundle.vim
+   call vundle#begin()
+
+   " let Vundle manage Vundle, required
+   Plugin 'VundleVim/Vundle.vim'
+
+   " Add your plugins here
+   Plugin 'preservim/nerdtree'
+   Plugin 'tpope/vim-fugitive'
+   Plugin 'Konfekt/vim-wsl-copy-paste'
+
+   call vundle#end()            " required
+   filetype plugin indent on    " required
+   ```
+
+3. Save the changes to your `.vimrc` file and run the following command in Vim to install the plugins:
+   ```
+   :PluginInstall
+   ```
+
+# Using Autocommands
+
+Autocommands in Vim allow you to execute commands automatically in response to specific events. Here are some examples of how to use autocommands:
+
+1. Highlight specific words in files with a `.tid` extension:
+   ```
+   autocmd BufRead,BufNewFile *.tid syntax match InnovationGroup "\<[Ii]nnovat\w*\>"
+   ```
+
+2. Change the color of the cursor line when entering and leaving insert mode:
+   ```
+   " Change Color when entering Insert Mode
+   autocmd InsertEnter * highlight  CursorLine ctermfg=NONE
+
+   " Revert Color to default when leaving Insert Mode
+   autocmd InsertLeave * highlight  CursorLine ctermfg=LightBlue
+   ```
+
+3. Set UTF-8 as the default encoding for commit messages:
+   ```
+   autocmd BufReadPre COMMIT_EDITMSG,MERGE_MSG,git-rebase-todo setlocal fileencodings=utf-8
+   ```
+
+4. Remember the positions in files with some git-specific exceptions:
+   ```
+   autocmd BufReadPost *
+     \ if line("'\"") > 0 && line("'\"") <= line("$")
+     \           && &filetype !~# 'commit\|gitrebase'
+     \           && expand("%") !~ "ADD_EDIT.patch"
+     \           && expand("%") !~ "addp-hunk-edit.diff" |
+     \   exe "normal g`\"" |
+     \ endif
+   ```
+
+5. Set the filetype to `diff` for files with a `.patch` extension:
+   ```
+   autocmd BufNewFile,BufRead *.patch set filetype=diff
+   ```
+
+6. Highlight trailing whitespace in diff files:
+   ```
+   autocmd Filetype diff
+     \ highlight WhiteSpaceEOL ctermbg=red |
+     \ match WhiteSpaceEOL /\(^+.*\)\@<=\s\+$/
+   ```


### PR DESCRIPTION
Fixes #1

Clean up `.vimrc` file and add explanations for Vundle and autocommands.

* **Translate comments to English**
  - Translate German comments to English in `.vimrc`.

* **Add explanations**
  - Add explanations for Vundle installation and plugin management in `README.md`.
  - Add explanations for using autocommands in `README.md`.

* **Remove duplications**
  - Remove duplicate `highlight ShareGroup` definition in `.vimrc`.
  - Remove duplicate `LearnGroup` syntax match in `.vimrc`.

